### PR TITLE
Add supported containers to play vvc codec of file

### DIFF
--- a/DecoderPluginVLC/vvc_demux.cpp
+++ b/DecoderPluginVLC/vvc_demux.cpp
@@ -167,7 +167,7 @@ static int ProbeVVC(const uint8_t* p_peek, size_t i_peek, vvc_probe_ctx_t* p_ctx
 int VvcDecoder::OpenDemux(vlc_object_t* p_this)
 {
   vvc_probe_ctx_t ctx = { 0, 0, 0 };
-  const char* rgi_psz_ext[] = { ".h266", ".266", ".bin", ".bit", ".raw", NULL };
+  const char* rgi_psz_ext[] = { ".h266", ".266", ".bin", ".bit", ".raw", ".vvc", ".mp4", ".mkv", ".webm", ".m4v", NULL };
   const char* rgi_psz_mime[] = { "video/H266", "video/h266", "video/vvc", NULL };
 
   demux_sys_t* p_sys;


### PR DESCRIPTION
Hello, @FabriceUrban! I would like my pull request to review code:

Example link: https://www.elecard.com/storage/video/Traffic_1920x1080.webm

Playing .webm (vvc codec) will play automatically of vvc codec. Normally .webm (like AV1 codec) will also play automatically of av1 codec.

.webm, .mp4, .vvc, .mkv and .m4v can also detect VVC codec, else detects other codecs as well too.

Tested on Windows and Linux.

See screenshot:
![fixedcontainerofvlcvtmdecoder](https://user-images.githubusercontent.com/88035011/173004407-b3c3058e-d835-43ea-9338-b13473f57acb.png)


- Martin Eesmaa